### PR TITLE
Transfer only committed logs **only**

### DIFF
--- a/src/core.hpp
+++ b/src/core.hpp
@@ -39,7 +39,7 @@ public:
     Status GetStatus() const { return status_; }
     int CommitID() const { return commit_; }
     int OpID() const { return op_; }
-    const std::vector<std::pair<int, std::string>>&
+    const std::vector<std::pair<int, MsgClientOp>>&
         GetCommittedLogs() const { return logs_; }
 
     void HealthTimeoutTicked();
@@ -55,8 +55,8 @@ private:
     Status status_;
     int op_;
     int commit_;
-    std::vector<std::pair<int,std::string>> logs_;
-    std::string op_str_;
+    std::vector<std::pair<int, MsgClientOp>> logs_;
+    MsgClientOp cliop_;
 
     bool prepare_sent_;
     unsigned latest_healthtick_received_;

--- a/src/core_impl_test.cpp
+++ b/src/core_impl_test.cpp
@@ -208,7 +208,7 @@ public:
   {
     enqueueTask(pts_, [from, to, ml, this]() {
       auto ret = callDecideSync(from, to, TstMsgType::GetMissingLogs, ml.view);
-      MsgMissingLogsResponse mlresp { "err mlllogs" };
+      MsgMissingLogsResponse mlresp { ml.view, "err mlllogs" };
       if (!ret) {
         std::lock_guard<std::mutex> lck(engines_mtxs_[to]);
         mlresp = engines_[to]->ConsumeMsg(from, ml);

--- a/src/msgs.hpp
+++ b/src/msgs.hpp
@@ -9,13 +9,21 @@ namespace vsrepl {
 struct MsgClientOp {
     int clientid;
     std::string opstr;
+    uint64_t cliopid; // prevents opstr to re-execute together with clientid
+
+    std::string toString() const {
+        return std::to_string(clientid) + "/" + std::to_string(cliopid) + "/" + opstr;
+    }
+    bool operator==(const MsgClientOp& o) const {
+        return o.clientid == clientid && o.opstr == opstr && o.cliopid == cliopid;
+    }
 };
 
 struct MsgPrepare {
     int view;
     int op;
     int commit;
-    std::string opstr;
+    MsgClientOp cliop;
 };
 
 struct MsgStartViewChange {
@@ -29,15 +37,14 @@ struct MsgDoViewChange {
 // Leader's command to all possible Followers
 struct MsgStartView {
     int view;
-    unsigned last_commit;
+    int last_commit;
 };
 
 // Followers' response to the Leader candidate
 struct MsgStartViewResponse {
     std::string err;
     int last_commit;
-    int last_op;
-    std::vector<std::pair<int, std::string>> missing_entries;
+    std::vector<std::pair<int, MsgClientOp>> missing_entries;
 };
 
 struct MsgPrepareResponse {
@@ -51,9 +58,11 @@ struct MsgGetMissingLogs {
 };
 
 struct MsgMissingLogsResponse {
+    int view;
     std::string err;
-    std::pair<int, std::string> op_log;
-    std::vector<std::pair<int, std::string>> comitted_logs;
+    std::pair<int, MsgClientOp> op_log;
+    std::vector<std::pair<int, MsgClientOp>> comitted_logs;
+    unsigned hashoflast;
 };
 
 }


### PR DESCRIPTION
Do not add no-yet-committed logs to missing-logs transfer list but include only committed logs.
We'll require client code to make special logic in case of a log-commit-timeout - coming soon.