### PR TITLE
feat: rolling hashsum to the committed logs & discard minority committed logs for consistency

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,7 +2,7 @@
 enable_testing()
 
 add_executable(
-    core_test core_impl_test.cpp core_test.cpp)
+    core_test hasher.cpp core_impl_test.cpp core_test.cpp)
 
 target_link_libraries(core_test
   PRIVATE gtest_main gmock)

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -133,7 +133,7 @@ ViewstampedReplicationEngine<TMsgDispatcher, TStateMachine>::ConsumeMsg(
   } else {
     cout << replica_ << ":" << view_ << " (SV) my view is bigger than received v:"
       << sv.view << "!! skipping..." << endl;
-    return MsgStartViewResponse { "My view is bigger than received v:" + std::to_string(sv.view) };
+    return MsgStartViewResponse { view_, "My view is bigger than received v:" + std::to_string(sv.view) };
   }
 
   std::vector<std::pair<int, MsgClientOp>> missing_logs;
@@ -142,7 +142,7 @@ ViewstampedReplicationEngine<TMsgDispatcher, TStateMachine>::ConsumeMsg(
       missing_logs.push_back(logs_[i]);
     else break;
 
-  return MsgStartViewResponse { "", commit_, std::move(missing_logs) };
+  return MsgStartViewResponse { view_, "", commit_, std::move(missing_logs) };
 }
 
 template <typename TMsgDispatcher, typename TStateMachine>
@@ -238,7 +238,7 @@ int ViewstampedReplicationEngine<TMsgDispatcher, TStateMachine>::ConsumeReply(
         << " lastcommit:" << svresp.last_commit << "; I am not the Leader " << endl;
     return -1;
   }
-  auto [isdup, idx] = checkDuplicate(trackDups_SVResps_, from, svresp.last_commit);
+  auto [isdup, idx] = checkDuplicate(trackDups_SVResps_, from, svresp.view);
   if (isdup)
     return 0; // double sent
 

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -228,6 +228,7 @@ ViewstampedReplicationEngine<TMsgDispatcher, TStateMachine>::ConsumeMsg(
     dispatcher_.SendMsg(view_ % totreplicas_, MsgGetMissingLogs { view_, commit_ });
   }
 
+  ret.op = op_;
   return ret;
 }
 
@@ -401,7 +402,7 @@ void ViewstampedReplicationEngine<TMsgDispatcher, TStateMachine>::HealthTimeoutT
     for (int i = 0; i < totreplicas_; ++i) {
       if (i != replica_) {
         if (status_ == Status::Normal)
-          dispatcher_.SendMsg(i, MsgPrepare { view_, commit_, op_, log_hash_, MsgClientOp {} });
+          dispatcher_.SendMsg(i, MsgPrepare { view_, commit_, op_, log_hash_, cliop_ });
         else
           dispatcher_.SendMsg(i, MsgPrepare { view_, -1, -1, 1, MsgClientOp {} });
       }

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -156,7 +156,7 @@ int ViewstampedReplicationEngine<TMsgDispatcher, TStateMachine>::ConsumeMsg(
     return 0;
   }
 
-  if (op_ != commit_)
+  if (op_ != commit_ || status_ != Status::Normal) // failed, retry
     return -1;
   ++op_;
   cliop_ = msg;

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -149,7 +149,7 @@ template <typename TMsgDispatcher, typename TStateMachine>
 int ViewstampedReplicationEngine<TMsgDispatcher, TStateMachine>::ConsumeMsg(
     const MsgClientOp& msg)
 {
-  cout << replica_ << ":" << view_ << " (CliOp) " << msg.clientid << " cliop:" << msg.toString()
+  cout << replica_ << ":" << view_ << " (CliOp) " << msg.clientid << " msg.opstr:" << msg.toString()
        << " commit:" << op_ << "/" << commit_ << endl;
   if ((view_ % totreplicas_) != replica_) {
     dispatcher_.SendMsg(view_ % totreplicas_, msg);
@@ -204,16 +204,6 @@ ViewstampedReplicationEngine<TMsgDispatcher, TStateMachine>::ConsumeMsg(
       commit_ = logs_.back().first;
     op_ = commit_;
   }
-
-  // if (msgpr.loghash != log_hash_) {
-  //   cout << replica_ << ":" << view_ << "<-" << from << " v:" << msgpr.view
-  //        << " my commit: " << commit_ << " hash:" << log_hash_
-  //        << " != msgpr.commit:" << msgpr.commit
-  //        << " msgpr.hash:" << msgpr.loghash << " resetting my commit!!" << endl;
-  //   commit_ = msgpr.commit;
-  //   while (msgpr.commit > logs_.back().first)
-  //     logs_.pop_back();
-  // }
 
   healthcheck_tick_ = latest_healthtick_received_;
   if (msgpr.commit == op_) {

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -191,8 +191,11 @@ ViewstampedReplicationEngine<TMsgDispatcher, TStateMachine>::ConsumeMsg(
     return ret;
   }
 
-  if (!(msgpr.commit == -1 && msgpr.op == -1 && msgpr.loghash == 1)
-      && (commit_ > msgpr.commit || (commit_ == msgpr.commit && msgpr.loghash != log_hash_))) {
+  healthcheck_tick_ = latest_healthtick_received_;
+  if (msgpr.commit == -1 && msgpr.op == -1 && msgpr.loghash == 1)
+    return ret;
+
+  if (commit_ > msgpr.commit || (commit_ == msgpr.commit && msgpr.loghash != log_hash_)) {
     cout << replica_ << ":" << view_ << "<-" << from << " (PREP) pop-back sz:" << logs_.size()
          << " commit:" << op_ << "/" << commit_
          << " msgpr.commit:" << msgpr.op << "/" << msgpr.commit
@@ -205,7 +208,6 @@ ViewstampedReplicationEngine<TMsgDispatcher, TStateMachine>::ConsumeMsg(
     op_ = commit_;
   }
 
-  healthcheck_tick_ = latest_healthtick_received_;
   if (msgpr.commit == op_) {
     if (op_ > commit_) {
       cout << replica_ << ":" << view_ << "<-" << from << " (PREP) committing op:" << op_

--- a/src/core.hpp
+++ b/src/core.hpp
@@ -13,7 +13,6 @@ enum class Status : char {
   Change,
 };
 
-
 template <typename TMsgDispatcher, typename TStateMachine>
 class ViewstampedReplicationEngine {
 public:
@@ -41,6 +40,7 @@ public:
     int OpID() const { return op_; }
     const std::vector<std::pair<int, MsgClientOp>>&
         GetCommittedLogs() const { return logs_; }
+    std::size_t GetHash() const noexcept { return log_hash_; }
 
     void HealthTimeoutTicked();
 
@@ -55,6 +55,7 @@ private:
     Status status_;
     int op_;
     int commit_;
+    std::size_t log_hash_;
     std::vector<std::pair<int, MsgClientOp>> logs_;
     MsgClientOp cliop_;
 

--- a/src/core_impl_test.cpp
+++ b/src/core_impl_test.cpp
@@ -169,7 +169,7 @@ public:
   {
     enqueueTask(pts_, [from, to, sv, this]() {
       auto ret = callDecideSync(from, to, TstMsgType::StartView, sv.view);
-      MsgStartViewResponse svr{ "failxd-13 network" };
+      MsgStartViewResponse svr{ sv.view, "failxd-13 network" };
       if (!ret) {
         std::lock_guard<std::mutex> lck(engines_mtxs_[to]);
         svr = engines_[to]->ConsumeMsg(from, sv);

--- a/src/core_test.cpp
+++ b/src/core_test.cpp
@@ -792,18 +792,25 @@ TEST(CoreWithBuggyNetwork, ViewChange_BuggyNetworkNoShuffle_Scenarios)
 
   // Check that re-joined island gets ops successfully
   for (int i = 0; i < 21; ++i) {
-    if (vsreps[1].OpID() == 4 && vsreps[1].CommitID() == 4
+    if (vsreps[0].OpID() == 4 && vsreps[0].CommitID() == 4
+        && vsreps[1].OpID() == 4 && vsreps[1].CommitID() == 4
         && vsreps[2].OpID() == 4 && vsreps[2].CommitID() == 4)
       break;
     ASSERT_LT(i, 20);
     sleep_for(std::chrono::milliseconds(50));
   }
-  ASSERT_EQ(4, vsreps[1].CommitID());
-  ASSERT_EQ(4, vsreps[2].CommitID());
 
-  ASSERT_EQ(5, vsreps[0].GetCommittedLogs().size());
   {
     auto&& logs = vsreps[1].GetCommittedLogs();
+    ASSERT_EQ(5, logs.size());
+    ASSERT_EQ(std::make_pair(0, MsgClientOp { 1212, "x=12" }), logs[0]);
+    ASSERT_EQ(std::make_pair(1, MsgClientOp { 1212, "x=to2_isolated1_v2-6655" }), logs[1]);
+    ASSERT_EQ(std::make_pair(2, MsgClientOp { 5908, "xu=75" }), logs[2]);
+    ASSERT_EQ(std::make_pair(3, MsgClientOp { 5908, "xu=to1_joining40_beforeisolating12_v6-004" }), logs[3]);
+    ASSERT_EQ(std::make_pair(4, MsgClientOp { 1571, "y=to3_isolated12_v8-1563" }), logs[4]);
+  }
+  {
+    auto&& logs = vsreps[0].GetCommittedLogs();
     ASSERT_EQ(5, logs.size());
     ASSERT_EQ(std::make_pair(0, MsgClientOp { 1212, "x=12" }), logs[0]);
     ASSERT_EQ(std::make_pair(1, MsgClientOp { 1212, "x=to2_isolated1_v2-6655" }), logs[1]);

--- a/src/core_test.cpp
+++ b/src/core_test.cpp
@@ -684,7 +684,7 @@ TEST(CoreWithBuggyNetwork, ViewChange_BuggyNetworkNoShuffle_Scenarios)
   vsreps[4].ConsumeMsg(MsgClientOp { 1688, "xt=to4_isolated40_v4to6-002" });
   vsreps[1].ConsumeMsg(MsgClientOp { 5908, "xu=75" });
   for (int i = 0; i < 21; ++i) {
-    if (vsreps[1].CommitID() > 1) // vsreps[1].OpID() == vsreps[1].CommitID()
+    if (vsreps[1].OpID() == vsreps[1].CommitID()) // vsreps[1].CommitID() > 1
       break;
     ASSERT_LT(i, 20);
     sleep_for(std::chrono::milliseconds(50));

--- a/src/core_test.cpp
+++ b/src/core_test.cpp
@@ -329,18 +329,21 @@ TEST(CoreTest, MissingLogs)
   }
   ASSERT_EQ(0, cr1.OpID());
   {
-    cr1.ConsumeMsg(leader, MsgPrepare { view, 0, 0, 593537993421075790ull, MsgClientOp { 1237, "" } });
+    const auto hh = cr1.GetHash();
+    cr1.ConsumeMsg(leader, MsgPrepare { view, 0, 0, hh, MsgClientOp { 1237, "" } });
     ASSERT_EQ(0, missing_log_reqs.size());
   }
   ASSERT_EQ(0, cr1.CommitID());
   ASSERT_EQ(0, cr1.OpID());
 
   {
-    cr1.ConsumeMsg(leader, MsgPrepare { view, 4, 0, 593537993421075790ull, MsgClientOp { 1237, "xzz=efrs" } });
+    const auto hh = cr1.GetHash();
+    cr1.ConsumeMsg(leader, MsgPrepare { view, 4, 0, hh, MsgClientOp { 1237, "xzz=efrs" } });
     ASSERT_EQ(0, cr1.CommitID());
     ASSERT_EQ(4, cr1.OpID());
     ASSERT_EQ(0, missing_log_reqs.size());
-    cr1.ConsumeMsg(leader, MsgPrepare { view, 5, 4, 14974115470896151948ull, MsgClientOp { 1237, "azx=342" } });
+    const auto hh2 = cr1.GetHash();
+    cr1.ConsumeMsg(leader, MsgPrepare { view, 5, 4, hh2, MsgClientOp { 1237, "azx=342" } });
     ASSERT_EQ(4, cr1.CommitID());
     ASSERT_EQ(5, cr1.OpID());
     ASSERT_EQ(0, missing_log_reqs.size());
@@ -681,7 +684,7 @@ TEST(CoreWithBuggyNetwork, ViewChange_BuggyNetworkNoShuffle_Scenarios)
   vsreps[4].ConsumeMsg(MsgClientOp { 1688, "xt=to4_isolated40_v4to6-002" });
   vsreps[1].ConsumeMsg(MsgClientOp { 5908, "xu=75" });
   for (int i = 0; i < 21; ++i) {
-    if (vsreps[1].OpID() == vsreps[1].CommitID()) // vsreps[1].CommitID() > 1
+    if (vsreps[1].CommitID() > 1) //vsreps[1].OpID() == vsreps[1].CommitID()
       break;
     ASSERT_LT(i, 20);
     sleep_for(std::chrono::milliseconds(50));

--- a/src/core_test.cpp
+++ b/src/core_test.cpp
@@ -334,7 +334,6 @@ TEST(CoreTest, MissingLogs)
   }
   ASSERT_EQ(0, cr1.CommitID());
   ASSERT_EQ(0, cr1.OpID());
-  ASSERT_EQ(593537993421075790ull, cr1.GetHash());
 
   {
     cr1.ConsumeMsg(leader, MsgPrepare { view, 4, 0, 593537993421075790ull, MsgClientOp { 1237, "xzz=efrs" } });
@@ -344,7 +343,6 @@ TEST(CoreTest, MissingLogs)
     cr1.ConsumeMsg(leader, MsgPrepare { view, 5, 4, 14974115470896151948ull, MsgClientOp { 1237, "azx=342" } });
     ASSERT_EQ(4, cr1.CommitID());
     ASSERT_EQ(5, cr1.OpID());
-    ASSERT_EQ(14974115470896151948ull, cr1.GetHash());
     ASSERT_EQ(0, missing_log_reqs.size());
   }
   ASSERT_EQ(4, cr1.CommitID());
@@ -418,7 +416,6 @@ TEST(CoreTest, PrevLeaderDiscardsCommitIfLeaderDontKnow2)
   cr0.ConsumeMsg(leader_cur, MsgPrepare { view_cur, 0, -1, 0, MsgClientOp { 1445, "to0=x", 1 } });
   cr0.ConsumeReply(leader_cur, MsgPrepareResponse { "", 0 }); // leader:0 will persist
   ASSERT_EQ(0, cr0.CommitID());
-  ASSERT_EQ(16509394309380172938ull, cr0.GetHash());
   ASSERT_EQ(0, missing_log_reqs.size());
   // however, as leader_next doesn't know about this commit, it should be reverted
   cr0.ConsumeMsg(leader_next, MsgPrepare { view_next, 1, 0, 6747, MsgClientOp { 123, "to1=y", 2 } });
@@ -514,8 +511,8 @@ TEST(CoreWithBuggyNetwork, ViewChange_BuggyNetworkNoShuffle_Scenarios)
   ASSERT_THAT(cnt, ::testing::Gt(3));
 
   vsreps[0].ConsumeMsg(MsgClientOp { 1212, "x=to0_isolated0_v1-1314" });
-  // Make replica:0 re-joined
-  cout << "*** Make replica:0 re-joined" << endl;
+  // re-join replica:0
+  cout << "*** re-join replica:0" << endl;
   buggynw.SetDecideFun(
       [](int from, int to, FakeTMsgBuggyNetwork<VSREtype>::TstMsgType, int vw) { return 0; });
   for (int i = 0; i < 40; ++i) {
@@ -641,8 +638,8 @@ TEST(CoreWithBuggyNetwork, ViewChange_BuggyNetworkNoShuffle_Scenarios)
   ASSERT_EQ(4, vsreps[4].View());
   ASSERT_EQ(Status::Normal, vsreps[4].GetStatus());
 
-  // Make replica:2-3 re-joined
-  cout << "*** Make replica:2-3 re-joined" << endl;
+  // re-join replica:2-3
+  cout << "*** re-join replica:2-3" << endl;
   buggynw.SetDecideFun(
       [](int from, int to, FakeTMsgBuggyNetwork<VSREtype>::TstMsgType, int vw) { return 0; });
   for (int i = 0; i < 20; ++i) {
@@ -698,8 +695,8 @@ TEST(CoreWithBuggyNetwork, ViewChange_BuggyNetworkNoShuffle_Scenarios)
   }
   ASSERT_EQ(2, vsreps[1].CommitID());
 
-  // Make replica:4-0 re-joined
-  cout << "*** Make replica:4-0 re-joined" << endl;
+  // re-join replica:4-0
+  cout << "*** re-join replica:4-0" << endl;
   buggynw.SetDecideFun(
       [](int from, int to, FakeTMsgBuggyNetwork<VSREtype>::TstMsgType, int vw) { return 0; });
   vsreps[1].ConsumeMsg(MsgClientOp { 5908, "xu=to1_joining40_beforeisolating12_v6-004" });
@@ -792,9 +789,9 @@ TEST(CoreWithBuggyNetwork, ViewChange_BuggyNetworkNoShuffle_Scenarios)
   ASSERT_EQ(4, vsreps[0].OpID());
   ASSERT_EQ(4, vsreps[4].OpID());
   // --------------------------------------------------------------
-  // Make replica:1-2 re-joined (join them to majority island)
+  // re-join replica:1-2 (join them to majority island)
   // --------------------------------------------------------------
-  cout << "*** Make replica:1-2 non-isolated again (join them to majority island)" << endl;
+  cout << "*** re-join replica:1-2 (join them to majority island)" << endl;
   buggynw.SetDecideFun(
       [](int from, int to, FakeTMsgBuggyNetwork<VSREtype>::TstMsgType, int vw) { return 0; });
   for (int i = 0; i < 20; ++i) {

--- a/src/hasher.cpp
+++ b/src/hasher.cpp
@@ -1,0 +1,18 @@
+#include "hasher.hpp"
+
+namespace vsrepl
+{
+
+std::size_t mergeLogsHashes(LogsIterTyp beg, LogsIterTyp end, std::size_t inithash)
+{
+  for (; beg != end; ++beg) {
+    auto h = std::hash<int> {}(beg->first);
+    inithash ^= (h << 1);
+    // inithash ^= (1 << (beg.first % 17));
+    h = std::hash<MsgClientOp>{}(beg->second);
+    inithash ^= (h << 1);
+  }
+  return inithash;
+}
+
+}

--- a/src/hasher.hpp
+++ b/src/hasher.hpp
@@ -1,0 +1,26 @@
+#ifndef VSREPL_HASHER_INCLUDED_
+#define VSREPL_HASHER_INCLUDED_ 1
+
+#include "msgs.hpp"
+
+
+namespace std {
+
+template <>
+struct hash<vsrepl::MsgClientOp> {
+  std::size_t operator()(const vsrepl::MsgClientOp& cliop) const noexcept
+  {
+    return cliop.hash();
+  }
+};
+
+}
+
+
+namespace vsrepl
+{
+using LogsIterTyp = std::vector<std::pair<int, MsgClientOp>>::const_iterator;
+
+std::size_t mergeLogsHashes(LogsIterTyp beg, LogsIterTyp end, std::size_t inithash = 0);
+}
+#endif

--- a/src/msgs.hpp
+++ b/src/msgs.hpp
@@ -1,6 +1,9 @@
 #ifndef TSTAMPED_MSGS_INCLUDED_
 #define TSTAMPED_MSGS_INCLUDED_ 1
 
+#include "msgs.hpp"
+
+#include <functional>
 #include <string>
 #include <vector>
 
@@ -14,8 +17,15 @@ struct MsgClientOp {
     std::string toString() const {
         return std::to_string(clientid) + "/" + std::to_string(cliopid) + "/" + opstr;
     }
-    bool operator==(const MsgClientOp& o) const {
+    bool operator==(const vsrepl::MsgClientOp& o) const noexcept {
         return o.clientid == clientid && o.opstr == opstr && o.cliopid == cliopid;
+    }
+    std::size_t hash() const noexcept {
+        auto h1 = std::hash<int>{}(clientid);
+        auto h2 =  std::hash<std::string>{}(opstr);
+        auto h3 =  std::hash<uint64_t>{}(cliopid);
+        h1 ^= (h2 << 1);
+        return h1 ^ (h3 << 1);
     }
 };
 
@@ -23,6 +33,7 @@ struct MsgPrepare {
     int view;
     int op;
     int commit;
+    std::size_t loghash;
     MsgClientOp cliop;
 };
 

--- a/src/msgs.hpp
+++ b/src/msgs.hpp
@@ -53,6 +53,7 @@ struct MsgStartView {
 
 // Followers' response to the Leader candidate
 struct MsgStartViewResponse {
+    int view;
     std::string err;
     int last_commit;
     std::vector<std::pair<int, MsgClientOp>> missing_entries;


### PR DESCRIPTION
minority committed logs could be discarded for consistency.
Client node is supposed to receive confirmations and wait accordingly -
coming soon.