### PR TITLE
engines to return leader redirect message instead of accepting ops

### DIFF
--- a/src/core.hpp
+++ b/src/core.hpp
@@ -5,6 +5,7 @@
 
 #include <chrono>
 #include <thread>
+#include <variant>
 
 namespace vsrepl {
 
@@ -22,7 +23,8 @@ public:
     void Start();
     void Stop();
 
-    int ConsumeMsg(const MsgClientOp&);
+    std::variant<std::monostate, MsgLeaderRedirect, int>
+        ConsumeMsg(const MsgClientOp&);
     int ConsumeMsg(int from, const MsgStartViewChange&);
     int ConsumeMsg(int from, const MsgDoViewChange&);
     MsgStartViewResponse ConsumeMsg(int from, const MsgStartView&);

--- a/src/core_impl_test.cpp
+++ b/src/core_impl_test.cpp
@@ -155,7 +155,9 @@ public:
       auto ret = callDecideSync(from, to, TstMsgType::ClientOp, -1);
       if (!ret) {
         std::lock_guard<std::mutex> lck(engines_mtxs_[to]);
-        ret = engines_[to]->ConsumeMsg(cliop);
+        const auto v = engines_[to]->ConsumeMsg(cliop);
+        if (std::holds_alternative<int>(v)) ret = std::get<int>(v);
+        else ret = -551;
       }
       return ret;
     });

--- a/src/core_test.cpp
+++ b/src/core_test.cpp
@@ -543,7 +543,7 @@ TEST(CoreWithBuggyNetwork, ViewChange_BuggyNetworkNoShuffle_Scenarios)
     [&buggynw](void*) { buggynw.CleanEnginesStop(); });
 
 
-  buggynw.SendMsg(-1, 2, MsgClientOp{ clientMinIdx, "x=12" });
+  buggynw.SendMsg(-1, 0, MsgClientOp{ clientMinIdx, "x=12" });
   for (int i = 0; i < 151; ++i) {
     if (vsreps[0].CommitID() == 0
         // TODO: Normally we need only wait replica:0 CommitID but it has sporadic for now

--- a/src/msgs.hpp
+++ b/src/msgs.hpp
@@ -29,6 +29,11 @@ struct MsgClientOp {
     }
 };
 
+struct MsgLeaderRedirect {
+    int view;
+    int leader;
+};
+
 struct MsgPrepare {
     int view;
     int op;


### PR DESCRIPTION
when they are not the leader